### PR TITLE
ADD : embed asset folder inside binary for releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ bevy_ggrs = { version = "0.12", features = ["wasm-bindgen"] }
 bevy_matchbox = { version = "0.6.0", features = ["ggrs"] }
 bevy_asset_loader = "0.16.0"
 chrono = "0.4"
+bevy_embedded_assets = "0.7.0"
 
 [dependencies.uuid]
 version = "1.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use bevy_asset_loader::prelude::*;
 use bevy_ggrs::*;
 use bevy_matchbox::prelude::*;
 use bevy::math::Vec3Swizzles;
+use bevy_embedded_assets::EmbeddedAssetPlugin;
 
 use crate::component::{GameState, GameDuration, Playerid};
 use crate::system_module::network::{GgrsConfig, wait_socket};
@@ -39,7 +40,7 @@ fn main() {
                 ..default()
             }),
             ..default()
-        }))
+        }).build().add_before::<AssetPlugin, _>(EmbeddedAssetPlugin))
         .add_plugin(GameOverPlugin)
         .insert_resource(ClearColor(Color::WHITE))
         .insert_resource(GameDuration { game_time: Stopwatch::new() })


### PR DESCRIPTION
기존 버전 1.0 바이너리에 어셋 폴더가 포함되지 않아서 수동 작업이 필요했습니다.
해당 작업으로 더 이상 추가적으로 내려받지 않아도 됩니다.